### PR TITLE
Align 'Edit' button next to 'View' in client list for consistency

### DIFF
--- a/src/angular/hq/src/app/clients/client-list/client-list.component.html
+++ b/src/angular/hq/src/app/clients/client-list/client-list.component.html
@@ -102,29 +102,31 @@
     @for(client of records$ | async; track client.id) {
     <tr class="even:bg-gray-850 odd:bg-black-alt">
       <td class="border-b border-black py-2 pl-5">{{ client.name }}</td>
-      <td class="border-b border-black py-2">
+      <td class="border-b border-black py-2 pl-5">
         {{ (client.hourlyRate | currency) ?? "None" }}
       </td>
-      <td class="border-b border-black py-2">
+      <td class="border-b border-black py-2 pl-5">
         @if(client.billingEmail) {
         <a href="mailto:{{ client.billingEmail }}">{{ client.billingEmail }}</a>
         } @else { None }
       </td>
-      <td class="border-b border-black py-2">
+      <td class="border-b border-black py-2 pl-5">
         {{ client.officialName ?? "None" }}
       </td>
       <td class="border-b border-black py-2 text-right pr-5">
-        <a
+          <div class="text-nowrap divide-x divide-teal-200">
+            <a
           [routerLink]="['edit', client.id]"
-          class="text-teal-200 hover:text-teal-300"
+          class="text-teal-200 hover:text-teal-300 pr-3"
           >EDIT</a
         >
-      </td>
-      <td class="border-b border-black py-2 text-right pr-5">
-        <a [routerLink]="[client.id]" class="text-teal-200 hover:text-teal-300"
+         <a [routerLink]="[client.id]" class="text-teal-200 hover:text-teal-300 pl-3"
           >VIEW</a
         >
+       </div>
+        
       </td>
+      
     </tr>
     }
   </tbody>


### PR DESCRIPTION
## Changes


- **Right Alignment of the 'Edit' Button:** The 'Edit' button has been right-aligned within its table cell
 
- **Division with Visual Separator:** Introduced a vertical divider between the 'Edit' and 'View' buttons using a `divide-x` class.