### PR TITLE
CLI OutputHelper Fixes

### DIFF
--- a/src/dotnet/HQ.CLI/Commands/ChargeCodes/GetChargeCodesCommand.cs
+++ b/src/dotnet/HQ.CLI/Commands/ChargeCodes/GetChargeCodesCommand.cs
@@ -65,7 +65,7 @@ namespace HQ.CLI.Commands.ChargeCodes
                 return 1;
             }
 
-            AnsiConsole.Write(OutputHelper.Create(result.Value, result.Value.Records)
+            OutputHelper.Create(result.Value, result.Value.Records)
                 .WithColumn("ID", t => t.Id.ToString())
                 .WithColumn("ACTIVITY", t => t.Activity.ToString())
                 .WithColumn("CODE", t => t.Code)
@@ -75,8 +75,7 @@ namespace HQ.CLI.Commands.ChargeCodes
                 .WithColumn("QUOTE NAME", t => t.QuoteName)
                 .WithColumn("SERVICE AGREEMENT NAME", t => t.ServiceAgreementName)
                 .WithColumn("DESCRIPTION", t => t.Description, table: false, wide: true)
-                .Output(settings.Output)
-            );
+                .Output(settings.Output);
 
             return 0;
         }

--- a/src/dotnet/HQ.CLI/Commands/Clients/GetClientsCommand.cs
+++ b/src/dotnet/HQ.CLI/Commands/Clients/GetClientsCommand.cs
@@ -56,14 +56,13 @@ namespace HQ.CLI.Commands.Clients
                 return 1;
             }
 
-            AnsiConsole.Write(OutputHelper.Create(result.Value, result.Value.Records)
+            OutputHelper.Create(result.Value, result.Value.Records)
                 .WithColumn("ID", t => t.Id.ToString())
                 .WithColumn("NAME", t => t.Name)
                 .WithColumn("HOURLY RATE", t => t.HourlyRate?.ToString("C"))
                 .WithColumn("OFFICIAL NAME", t => t.OfficialName, table: false, wide: true)
                 .WithColumn("BILLING EMAIL", t => t.BillingEmail, table: false, wide: true)
-                .Output(settings.Output)
-            );
+                .Output(settings.Output);
 
             return 0;
         }

--- a/src/dotnet/HQ.CLI/Commands/Projects/GetProjectsCommand.cs
+++ b/src/dotnet/HQ.CLI/Commands/Projects/GetProjectsCommand.cs
@@ -55,7 +55,7 @@ namespace HQ.CLI.Commands.Projects
                 return 1;
             }
 
-            AnsiConsole.Write(OutputHelper.Create(result.Value, result.Value.Records)
+            OutputHelper.Create(result.Value, result.Value.Records)
                 .WithColumn("ID", t => t.Id.ToString())
                 .WithColumn("CHARGE CODE", t => t.ChargeCode)
                 .WithColumn("PROJECT NUM", t => t.ProjectNumber?.ToString())
@@ -65,8 +65,7 @@ namespace HQ.CLI.Commands.Projects
                 .WithColumn("START DATE", t => t.StartDate?.ToLongDateString(), table: false, wide: true)
                 .WithColumn("END DATE", t => t.EndDate?.ToLongDateString(), table: false, wide: true)
                 .WithColumn("STATUS", t => null, table: false, wide: true)
-                .Output(settings.Output)
-            );
+                .Output(settings.Output);
 
             return 0;
         }

--- a/src/dotnet/HQ.CLI/Commands/Staff/GetStaffCommand.cs
+++ b/src/dotnet/HQ.CLI/Commands/Staff/GetStaffCommand.cs
@@ -59,7 +59,7 @@ namespace HQ.CLI.Commands.Staff
                 return 1;
             }
 
-            AnsiConsole.Write(OutputHelper.Create(result.Value, result.Value.Records)
+            OutputHelper.Create(result.Value, result.Value.Records)
                 .WithColumn("ID", t => t.Id.ToString())
                 .WithColumn("NAME", t => t.Name)
                 .WithColumn("WORK HOURS", t => t.WorkHours.ToString())
@@ -67,8 +67,7 @@ namespace HQ.CLI.Commands.Staff
                 .WithColumn("JURISDICITON", t => t.Jurisdiciton.ToString(), table: false, wide: true)
                 .WithColumn("START DATE", t => t.StartDate?.ToLongDateString(), table: false, wide: true)
                 .WithColumn("END DATE", t => t.EndDate?.ToLongDateString(), table: false, wide: true)
-                .Output(settings.Output)
-            );
+                .Output(settings.Output);
 
             return 0;
         }

--- a/src/dotnet/HQ.CLI/OutputHelper.cs
+++ b/src/dotnet/HQ.CLI/OutputHelper.cs
@@ -48,7 +48,7 @@ namespace HQ.CLI
             return this;
         }
 
-        public IRenderable Output(OutputFormat output)
+        public void Output(OutputFormat output)
         {
             switch(output)
             {
@@ -68,8 +68,8 @@ namespace HQ.CLI
                     }
 
                     table.Border(TableBorder.None);
-
-                    return table;
+                    AnsiConsole.Write(table);
+                    break;
                 case OutputFormat.CSV:
                     {
                         using var stream = new MemoryStream();
@@ -94,7 +94,8 @@ namespace HQ.CLI
                         csv.Flush();
                         stream.Position = 0;
 
-                        return new Text(reader.ReadToEnd());
+                        Console.WriteLine(reader.ReadToEnd());
+                        break;
                     }
                 case OutputFormat.Json:
                 default:
@@ -108,7 +109,8 @@ namespace HQ.CLI
                         }
                     };
 
-                    return new JsonText(JsonSerializer.Serialize(_json, options));
+                    Console.WriteLine(JsonSerializer.Serialize(_json, options));
+                    break;
             }
         }
     }


### PR DESCRIPTION
* Switched output helper to use Console.WriteLine instead of AnsiConsole.Write for CSV and JSON output modes
* Prevents text wrapping causing malformed JSON and CSV format