### PR TITLE
Added logging and metrics with OpenTelemetry

### DIFF
--- a/.devcontainer/dotnet/devcontainer.json
+++ b/.devcontainer/dotnet/devcontainer.json
@@ -14,7 +14,8 @@
     "forwardPorts": [
         5186,
         "auth:8080",
-        "db:5432"
+        "db:5432",
+        "grafana:3000"
     ],
     "customizations": {
         "vscode": {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,7 @@ services:
     - AUTH_ISSUER=${HQ_AUTH_ISSUER}
     - AUTH_AUDIENCE=${HQ_AUTH_AUDIENCE}
     - AUTH_ADMIN_URL=${HQ_AUTH_ADMIN_URL}
+    - OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4317/
     volumes:
     - .:/workspace:cached
     - dotnet-nuget:/home/vscode/.nuget/
@@ -63,9 +64,60 @@ services:
     volumes:
     - db-data:/var/lib/postgresql/data
     - ./hack/db-init:/docker-entrypoint-initdb.d
+  grafana:
+    image: grafana/grafana:11.1.5
+    restart: unless-stopped
+    environment:
+      - GF_AUTH_ANONYMOUS_ENABLED=true
+      - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
+      - GF_AUTH_DISABLE_LOGIN_FORM=true
+      - GF_FEATURE_TOGGLES_ENABLE=traceqlEditor traceQLStreaming metricsSummary
+    volumes:
+      - ./grafana-datasource.yml:/etc/grafana/provisioning/datasources/grafana-datasource.yml
+  tempo-init:
+    image: &tempoImage grafana/tempo:2.6.0-rc.1
+    user: root
+    entrypoint:
+      - "chown"
+      - "10001:10001"
+      - "/var/tempo"
+    volumes:
+      - tempo-data:/var/tempo
+  tempo:
+    image: *tempoImage
+    command: [ "-config.file=/etc/tempo.yml" ]
+    volumes:
+      - ./tempo.yml:/etc/tempo.yml
+      - tempo-data:/var/tempo
+    depends_on:
+      - tempo-init
+  prometheus:
+    image: prom/prometheus
+    command:
+      - '--config.file=/etc/prometheus/prometheus.yml'
+      - --web.enable-remote-write-receiver
+      - --enable-feature=exemplar-storage
+      - --enable-feature=native-histograms
+    restart: unless-stopped
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml
+      - prom-data:/prometheus
+  otel-collector:
+    image: otel/opentelemetry-collector-contrib:0.108.0
+    volumes:
+      - ./otel-collector-config.yaml:/etc/otelcol-contrib/config.yaml
+  loki:
+    image: grafana/loki:3.1.0
+    command: "-config.file=/etc/loki/config.yaml -target=all"
+    volumes:
+      - ./loki-config.yaml:/etc/loki/config.yaml
+      - loki-data:/loki
 
 volumes:
   dotnet-nuget:
   hq-node_modules:
   hq-angular:
   db-data:
+  tempo-data:
+  prom-data:
+  loki-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,7 @@ services:
     - AUTH_ISSUER=${HQ_AUTH_ISSUER}
     - AUTH_AUDIENCE=${HQ_AUTH_AUDIENCE}
     - AUTH_ADMIN_URL=${HQ_AUTH_ADMIN_URL}
+    - HQ_SERVER__OPENTELEMETRY=true
     - OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4317/
     volumes:
     - .:/workspace:cached

--- a/grafana-datasource.yml
+++ b/grafana-datasource.yml
@@ -1,0 +1,59 @@
+apiVersion: 1
+
+datasources:
+- name: Loki
+  type: loki
+  uid: loki
+  access: proxy
+  orgId: 1
+  url: http://loki:3100
+  basicAuth: false
+  isDefault: false
+  version: 1
+  editable: false
+  jsonData:
+    httpMethod: GET
+    maxLines: 1000
+    derivedFields:
+    - datasourceUid: tempo
+      matcherRegex: trace_id
+      matcherType: label
+      name: Trace ID
+      url: $${__value.raw}
+      urlDisplayLabel: View Trace
+- name: Prometheus
+  type: prometheus
+  uid: prometheus
+  access: proxy
+  orgId: 1
+  url: http://prometheus:9090
+  basicAuth: false
+  isDefault: false
+  version: 1
+  editable: false
+  jsonData:
+    httpMethod: GET
+    exemplarTraceIdDestinations:
+    - name: trace_id
+      datasourceUid: tempo
+- name: Tempo
+  type: tempo
+  access: proxy
+  orgId: 1
+  url: http://tempo:3200
+  basicAuth: false
+  isDefault: true
+  version: 1
+  editable: false
+  apiVersion: 1
+  uid: tempo
+  jsonData:
+    httpMethod: GET
+    serviceMap:
+      datasourceUid: prometheus
+    tracesToLogs: Null
+    tracesToLogsV2:
+      datasourceUid: 'loki'
+      tags: [{ key: 'service.name', value: 'service_name' }]
+    lokiSearch:
+      datasourceUid: 'loki'

--- a/loki-config.yaml
+++ b/loki-config.yaml
@@ -1,0 +1,53 @@
+limits_config:
+  allow_structured_metadata: true
+
+auth_enabled: false
+
+server:
+  http_listen_port: 3100
+  grpc_listen_port: 9096
+
+common:
+  instance_addr: 127.0.0.1
+  path_prefix: /loki
+  storage:
+    filesystem:
+      chunks_directory: /loki/chunks
+      rules_directory: /loki/rules
+  replication_factor: 1
+  ring:
+    kvstore:
+      store: inmemory
+
+query_range:
+  results_cache:
+    cache:
+      embedded_cache:
+        enabled: true
+        max_size_mb: 100
+
+schema_config:
+  configs:
+    - from: 2024-01-01
+      store: tsdb
+      object_store: filesystem
+      schema: v13
+      index:
+        prefix: index_
+        period: 24h
+
+# ruler:
+#   alertmanager_url: http://localhost:9093
+
+# By default, Loki will send anonymous, but uniquely-identifiable usage and configuration
+# analytics to Grafana Labs. These statistics are sent to https://stats.grafana.org/
+#
+# Statistics help us better understand how Loki is used, and they show us performance
+# levels for most users. This helps us prioritize features and documentation.
+# For more information on what's sent, look at
+# https://github.com/grafana/loki/blob/main/pkg/analytics/stats.go
+# Refer to the buildReport method to see what goes into a report.
+#
+# If you would like to disable reporting, uncomment the following lines:
+#analytics:
+#  reporting_enabled: false

--- a/otel-collector-config.yaml
+++ b/otel-collector-config.yaml
@@ -1,0 +1,37 @@
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+      http:
+        endpoint: 0.0.0.0:4318
+processors:
+  batch:
+
+exporters:
+  otlp/tempo:
+    endpoint: tempo:4317
+    tls:
+      insecure: true
+  otlphttp/loki:
+    endpoint: http://loki:3100/otlp/
+  debug:
+    verbosity: detailed
+  prometheusremotewrite:
+    endpoint: "http://prometheus:9090/api/v1/write"
+
+service:
+  extensions: []
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [otlp/tempo]
+    logs:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [otlphttp/loki]
+    metrics:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [prometheusremotewrite]

--- a/prometheus.yml
+++ b/prometheus.yml
@@ -1,0 +1,11 @@
+global:
+  scrape_interval:     15s
+  evaluation_interval: 15s
+
+scrape_configs:
+  - job_name: 'prometheus'
+    static_configs:
+      - targets: [ 'localhost:9090' ]
+  - job_name: 'tempo'
+    static_configs:
+      - targets: [ 'tempo:3200' ]

--- a/src/dotnet/HQ.Server/HQ.Server.csproj
+++ b/src/dotnet/HQ.Server/HQ.Server.csproj
@@ -41,7 +41,6 @@
         <PackageReference Include="Npgsql" Version="8.0.3" />
         <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.2" />
         <PackageReference Include="Npgsql.OpenTelemetry" Version="8.0.3" />
-        <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.9.0" />
         <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.9.0" />
         <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.9.0" />
         <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.9.0" />

--- a/src/dotnet/HQ.Server/HQ.Server.csproj
+++ b/src/dotnet/HQ.Server/HQ.Server.csproj
@@ -40,6 +40,14 @@
         <PackageReference Include="Mjml.Net" Version="3.11.0" />
         <PackageReference Include="Npgsql" Version="8.0.3" />
         <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.2" />
+        <PackageReference Include="Npgsql.OpenTelemetry" Version="8.0.3" />
+        <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.9.0" />
+        <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.9.0" />
+        <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.9.0" />
+        <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.9.0" />
+        <PackageReference Include="OpenTelemetry.Instrumentation.Hangfire" Version="1.6.0-beta.1" />
+        <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.9.0" />
+        <PackageReference Include="OpenTelemetry.Instrumentation.Process" Version="0.5.0-beta.6" />
         <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
         <PackageReference Include="Swashbuckle.AspNetCore.Filters" Version="8.0.1" />
     </ItemGroup>

--- a/src/dotnet/HQ.Server/HQServerOptions.cs
+++ b/src/dotnet/HQ.Server/HQServerOptions.cs
@@ -9,6 +9,7 @@ public class HQServerOptions
     public const string Server = nameof(Server);
     public bool HangfireInMemory { get; set; }
     public bool AutoMigrate { get; set; }
+    public bool OpenTelemetry { get; set; }
 
     [Required]
     public Uri WebUrl { get; set; } = null!;

--- a/src/dotnet/HQ.Server/Program.cs
+++ b/src/dotnet/HQ.Server/Program.cs
@@ -276,14 +276,14 @@ app.Use(async (context, next) =>
     var activity = Activity.Current;
     activity?.AddTag("user.id", userId);
     activity?.AddTag("user.roles", userRoles);
-    activity?.AddTag("app.hq.staff_id", staffId);
+    activity?.AddTag("hq.staff_id", staffId);
 
     var logger = context.RequestServices.GetRequiredService<ILogger<Program>>();
     var logScope = new Dictionary<string, object?>()
     {
         { "user.id", userId },
         { "user.roles", userRoles },
-        { "app.hq.staff_id", staffId },
+        { "hq.staff_id", staffId },
     }.ToList();
 
     using (logger.BeginScope(logScope))

--- a/src/dotnet/HQ.Server/Program.cs
+++ b/src/dotnet/HQ.Server/Program.cs
@@ -1,4 +1,7 @@
+using System.Collections.Frozen;
+using System.Diagnostics;
 using System.Net;
+using System.Security.Claims;
 
 using Hangfire;
 
@@ -22,6 +25,13 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Options;
 using Microsoft.OpenApi.Models;
 
+using Npgsql;
+
+using OpenTelemetry.Logs;
+using OpenTelemetry.Metrics;
+using OpenTelemetry.Resources;
+using OpenTelemetry.Trace;
+
 using Swashbuckle.AspNetCore.Filters;
 using Swashbuckle.AspNetCore.SwaggerGen;
 
@@ -30,6 +40,32 @@ var builder = WebApplication.CreateBuilder(args);
 builder.Configuration.AddEnvironmentVariables("HQ_");
 
 var serverOptions = builder.Configuration.GetSection(HQServerOptions.Server).Get<HQServerOptions>() ?? throw new Exception("Error parsing configuration section 'Server'.");
+
+var serviceName = "hq-server";
+var serviceVersion = VersionNumber.GetVersionNumber();
+
+builder.Logging.AddOpenTelemetry(logging =>
+{
+    logging.IncludeFormattedMessage = true;
+    logging.IncludeScopes = true;
+});
+
+builder.Services.AddOpenTelemetry()
+    .ConfigureResource(resource => resource.AddService(serviceName: serviceName, serviceVersion: serviceVersion))
+    .WithTracing(tracing => tracing
+        .AddAspNetCoreInstrumentation()
+        .AddNpgsql()
+        .AddHttpClientInstrumentation()
+        .AddHangfireInstrumentation()
+        .AddOtlpExporter())
+    .WithMetrics(metrics => metrics
+        .AddAspNetCoreInstrumentation()
+        .AddProcessInstrumentation()
+        .AddHttpClientInstrumentation()
+        .SetExemplarFilter(ExemplarFilterType.TraceBased)
+        .AddOtlpExporter())
+    .WithLogging(logging => logging
+        .AddOtlpExporter());
 
 // Add services to the container.
 builder.Services.AddHealthChecks();
@@ -227,6 +263,28 @@ app.UseCors(policy => policy
 
 app.UseAuthentication();
 app.UseAuthorization();
+
+app.Use(async (context, next) =>
+{
+    var userId = context.User.FindFirstValue(ClaimTypes.NameIdentifier);
+    var userRoles = String.Join(", ", context.User.FindAll(ClaimTypes.Role).Select(t => t.Value));
+
+    var activity = Activity.Current;
+    activity?.AddTag("user.id", userId);
+    activity?.AddTag("user.roles", userRoles);
+
+    var logger = context.RequestServices.GetRequiredService<ILogger<Program>>();
+    var logScope = new Dictionary<string, object?>()
+    {
+        { "user.id", userId },
+        { "user.roles", userRoles },
+    }.ToList();
+
+    using (logger.BeginScope(logScope))
+    {
+        await next();
+    }
+});
 
 app.MapHangfireDashboard("/hangfire", new()
 {

--- a/src/dotnet/HQ.Server/Program.cs
+++ b/src/dotnet/HQ.Server/Program.cs
@@ -41,31 +41,34 @@ builder.Configuration.AddEnvironmentVariables("HQ_");
 
 var serverOptions = builder.Configuration.GetSection(HQServerOptions.Server).Get<HQServerOptions>() ?? throw new Exception("Error parsing configuration section 'Server'.");
 
-var serviceName = "hq-server";
-var serviceVersion = VersionNumber.GetVersionNumber();
-
-builder.Logging.AddOpenTelemetry(logging =>
+if (serverOptions.OpenTelemetry)
 {
-    logging.IncludeFormattedMessage = true;
-    logging.IncludeScopes = true;
-});
+    var serviceName = "hq-server";
+    var serviceVersion = VersionNumber.GetVersionNumber();
 
-builder.Services.AddOpenTelemetry()
-    .ConfigureResource(resource => resource.AddService(serviceName: serviceName, serviceVersion: serviceVersion))
-    .WithTracing(tracing => tracing
-        .AddAspNetCoreInstrumentation()
-        .AddNpgsql()
-        .AddHttpClientInstrumentation()
-        .AddHangfireInstrumentation()
-        .AddOtlpExporter())
-    .WithMetrics(metrics => metrics
-        .AddAspNetCoreInstrumentation()
-        .AddProcessInstrumentation()
-        .AddHttpClientInstrumentation()
-        .SetExemplarFilter(ExemplarFilterType.TraceBased)
-        .AddOtlpExporter())
-    .WithLogging(logging => logging
-        .AddOtlpExporter());
+    builder.Logging.AddOpenTelemetry(logging =>
+    {
+        logging.IncludeFormattedMessage = true;
+        logging.IncludeScopes = true;
+    });
+
+    builder.Services.AddOpenTelemetry()
+        .ConfigureResource(resource => resource.AddService(serviceName: serviceName, serviceVersion: serviceVersion))
+        .WithTracing(tracing => tracing
+            .AddAspNetCoreInstrumentation()
+            .AddNpgsql()
+            .AddHttpClientInstrumentation()
+            .AddHangfireInstrumentation()
+            .AddOtlpExporter())
+        .WithMetrics(metrics => metrics
+            .AddAspNetCoreInstrumentation()
+            .AddProcessInstrumentation()
+            .AddHttpClientInstrumentation()
+            .SetExemplarFilter(ExemplarFilterType.TraceBased)
+            .AddOtlpExporter())
+        .WithLogging(logging => logging
+            .AddOtlpExporter());
+}
 
 // Add services to the container.
 builder.Services.AddHealthChecks();

--- a/src/dotnet/HQ.Server/Program.cs
+++ b/src/dotnet/HQ.Server/Program.cs
@@ -266,18 +266,21 @@ app.UseAuthorization();
 
 app.Use(async (context, next) =>
 {
+    var staffId = context.User.GetStaffId();
     var userId = context.User.FindFirstValue(ClaimTypes.NameIdentifier);
     var userRoles = String.Join(", ", context.User.FindAll(ClaimTypes.Role).Select(t => t.Value));
 
     var activity = Activity.Current;
     activity?.AddTag("user.id", userId);
     activity?.AddTag("user.roles", userRoles);
+    activity?.AddTag("app.hq.staff_id", staffId);
 
     var logger = context.RequestServices.GetRequiredService<ILogger<Program>>();
     var logScope = new Dictionary<string, object?>()
     {
         { "user.id", userId },
         { "user.roles", userRoles },
+        { "app.hq.staff_id", staffId },
     }.ToList();
 
     using (logger.BeginScope(logScope))

--- a/src/dotnet/HQ.Server/appsettings.json
+++ b/src/dotnet/HQ.Server/appsettings.json
@@ -15,7 +15,8 @@
   "Server": {
     "HangfireInMemory": true,
     "AutoMigrate": true,
-    "WebUrl": null
+    "WebUrl": null,
+    "OpenTelemetry": false
   },
   "SMTP": {
     "Host": null,

--- a/tempo.yml
+++ b/tempo.yml
@@ -1,0 +1,60 @@
+stream_over_http_enabled: true
+server:
+  http_listen_port: 3200
+  log_level: info
+
+query_frontend:
+  search:
+    duration_slo: 5s
+    throughput_bytes_slo: 1.073741824e+09
+  trace_by_id:
+    duration_slo: 5s
+
+distributor:
+  receivers:                           # this configuration will listen on all ports and protocols that tempo is capable of.
+    jaeger:                            # the receives all come from the OpenTelemetry collector.  more configuration information can
+      protocols:                       # be found there: https://github.com/open-telemetry/opentelemetry-collector/tree/main/receiver
+        thrift_http:                   #
+        grpc:                          # for a production deployment you should only enable the receivers you need!
+        thrift_binary:
+        thrift_compact:
+    zipkin:
+    otlp:
+      protocols:
+        http:
+        grpc:
+    opencensus:
+
+ingester:
+  max_block_duration: 5m               # cut the headblock when this much time passes. this is being set for demo purposes and should probably be left alone normally
+
+compactor:
+  compaction:
+    block_retention: 1h                # overall Tempo trace retention. set for demo purposes
+
+metrics_generator:
+  registry:
+    external_labels:
+      source: tempo
+      cluster: docker-compose
+  storage:
+    path: /var/tempo/generator/wal
+    remote_write:
+      - url: http://prometheus:9090/api/v1/write
+        send_exemplars: true
+  traces_storage:
+    path: /var/tempo/generator/traces
+
+storage:
+  trace:
+    backend: local                     # backend configuration to use
+    wal:
+      path: /var/tempo/wal             # where to store the wal locally
+    local:
+      path: /var/tempo/blocks
+
+overrides:
+  defaults:
+    metrics_generator:
+      processors: [service-graphs, span-metrics, local-blocks] # enables metrics generator
+      generate_native_histograms: both


### PR DESCRIPTION
- Configured basic OpenTelemetry instrumentation for metrics/logging/traces.
- Updated docker compose
  - Added OTel collector that pushes metrics to Prometheus, logs to Loki and traces to Tempo
  - Added Grafana with data source configurations for above
  - Added config files for local development