### PR TITLE
Fixed styling discrepancies in the markdown display

### DIFF
--- a/src/angular/hq/src/app/staff-dashboard/staff-dashboard.component.html
+++ b/src/angular/hq/src/app/staff-dashboard/staff-dashboard.component.html
@@ -384,7 +384,7 @@
                 (onInit)="onEditorInit($event)"
               ></ngx-monaco-editor>
 
-              <div class="bg-black-alt h-full" second>
+              <div class="bg-black-alt h-full overflow-auto" second>
                 <hq-markdown [data]="plan.value"></hq-markdown>
               </div>
             </hq-panel>

--- a/src/angular/hq/src/styles.scss
+++ b/src/angular/hq/src/styles.scss
@@ -42,7 +42,7 @@ body {
   h5 {
     @apply font-rajdhani font-semibold text-base;
   }
-  p {
+  li:not(.markdown ul>li>ul>li) {
     @apply mb-[1rem];
   }
   a {
@@ -74,6 +74,15 @@ body {
   }
   tr td {
     @apply border-b border-black p-2 text-left;
+  }
+  code {
+    background-color: rgba(255, 255, 255, 0.05);
+    border-color: rgba(255, 255, 255, 0.2);
+    border-width: thin;
+    border-radius: 4px;
+    padding-right: 2px;
+    padding-left: 2px;
+    font-family: monospace;
   }
 }
 // Custom panel gutter

--- a/src/angular/hq/src/styles.scss
+++ b/src/angular/hq/src/styles.scss
@@ -42,7 +42,7 @@ body {
   h5 {
     @apply font-rajdhani font-semibold text-base;
   }
-  li:not(.markdown ul>li>ul>li) {
+  li:not(.markdown ul > li > ul > li) {
     @apply mb-[1rem];
   }
   a {


### PR DESCRIPTION
* Updated the markdown view portal background to extend to the entire viewing area
* Added syntax highlighting for `code` blocks
![code_changes](https://github.com/user-attachments/assets/0125d26c-a1b2-4328-adb2-680e975b52bf)

* Fixed inconsistent spacing for lists
![list_changes](https://github.com/user-attachments/assets/e56dcf70-59c7-44f6-b997-e94cd28285f9)
