### PR TITLE
Fix charge code deduplication and apply styling updates

### DIFF
--- a/src/angular/hq/src/app/Invoices/invoice-details/invoice-details-edit/invoice-details-edit.component.html
+++ b/src/angular/hq/src/app/Invoices/invoice-details/invoice-details-edit/invoice-details-edit.component.html
@@ -73,8 +73,8 @@
   <div class="overflow-hidden flex-auto">
     <div class="grid gap-0 relative">
       <main
-        class="flex flex-col bg-black-alt overflow-y-auto h-[calc(100dvh-(192px))]"
-      >
+        class="flex flex-col bg-black-alt overflow-y-auto h-[calc(100dvh-(192px))] pb-[25px]"
+        >
         <div
           class="bg-black-alt border-steel-blue-600 border-t sticky top-0 flex h-[53px] z-50"
         >
@@ -210,7 +210,7 @@
                 </div>
               </div>
               <div class="border-b border-black pt-14 pb-1 mb-3 font-bold">
-                Included Chargecodes
+                Included Charge Codes
               </div>
               @if (invoice$ | async; as invoice) {
                 @if (invoice.chargeCodes.length > 0) {

--- a/src/dotnet/HQ.Server/Services/InvoicesServicesV1.cs
+++ b/src/dotnet/HQ.Server/Services/InvoicesServicesV1.cs
@@ -174,7 +174,8 @@ namespace HQ.Server.Invoices
                         ProjectId = t.ProjectId,
                         QuoteId = t.QuoteId,
                     })
-                    .Distinct()
+                    .GroupBy(c => c.Id)
+                    .Select(g => g.First())
                     .ToList();
 
                 response.TotalHours = totalHours;


### PR DESCRIPTION
## Summary

Two related improvements to the invoice details page: fixes a server-side bug where charge codes were not being properly deduplicated, and applies pending UI styling updates from Nick.

## Changelog

**Changed**
- Replaced `.Distinct()` with `.GroupBy(c => c.Id).Select(g => g.First())` for server-side charge code deduplication, ensuring proper equality checking on the charge code object properties rather than reference equality
- Renamed "Included Chargecodes" section header to "Included Charge Codes" for consistency
- Added 25px bottom padding to the invoice details scrollable content area for better spacing at the bottom of the scroll region